### PR TITLE
Standardize API endpoints for frontend integration

### DIFF
--- a/backend/authentication/urls.py
+++ b/backend/authentication/urls.py
@@ -1,13 +1,12 @@
 from django.urls import path
 from rest_framework_simplejwt.views import TokenRefreshView
 
-from .views import LoginView, MeView, LogoutView, AdminTestView, RegisterView
+from .views import LoginView, MeView, LogoutView, RegisterView
 
 urlpatterns = [
     path("login/", LoginView.as_view()),
     path("refresh/", TokenRefreshView.as_view()),
     path("me/", MeView.as_view()),
     path("logout/", LogoutView.as_view()),
-    path("admin-test/", AdminTestView.as_view()),
     path("register/",RegisterView.as_view(),name="register"),
 ]

--- a/backend/purchases/urls.py
+++ b/backend/purchases/urls.py
@@ -1,15 +1,15 @@
 from django.urls import path
 
-from .views import (PurchaseCreateView,
-                    PurchaseListView,
-                    PurchaseDetailView,
-                    CustomerPurchaseHistoryView,
-                    PurchaseCancelView,
+from .views import (
+    PurchaseListCreateView,
+    PurchaseDetailView,
+    CustomerPurchaseHistoryView,
+    PurchaseCancelView,
 )
 
+
 urlpatterns = [
-    path("",PurchaseListView.as_view(),name="purchase-list",),
-    path("create/",PurchaseCreateView.as_view(),name="purchase-create",),
+    path("",PurchaseListCreateView.as_view(),name="purchase-list-create",),
     path("<int:pk>/",PurchaseDetailView.as_view(),name="purchase-detail",),
     path("customer/<str:customer_code>/",CustomerPurchaseHistoryView.as_view(),name="customer-history",),
     path("<int:pk>/cancel/",PurchaseCancelView.as_view(),name="purchase-cancel",),

--- a/backend/purchases/views.py
+++ b/backend/purchases/views.py
@@ -15,12 +15,34 @@ from .serializers import (
 )
 from .services import PurchaseService
 
-
-class PurchaseCreateView(APIView):
+class PurchaseListCreateView(APIView):
 
     permission_classes = [
         IsAdminOrEmployee
     ]
+
+    def get(self, request):
+
+        purchases = (
+            Purchase.objects
+            .select_related(
+                "customer__user",
+                "employee",
+            )
+            .prefetch_related(
+                "items__product"
+            )
+            .order_by("-created_at")
+        )
+
+        serializer = PurchaseSerializer(
+            purchases,
+            many=True
+        )
+
+        return Response(
+            serializer.data
+        )
 
     def post(self, request):
 
@@ -45,29 +67,6 @@ class PurchaseCreateView(APIView):
             serializer.data,
             status=status.HTTP_201_CREATED
         )
-
-
-class PurchaseListView(generics.ListAPIView):
-
-    queryset = (
-        Purchase.objects
-        .select_related(
-            "customer__user",
-            "employee",
-        )
-        .prefetch_related(
-            "items__product"
-        )
-        .order_by("-created_at")
-    )
-
-    serializer_class = PurchaseSerializer
-
-    permission_classes = [
-        IsAdminOrEmployee
-    ]
-
-
 class PurchaseDetailView(generics.RetrieveAPIView):
 
     queryset = (


### PR DESCRIPTION
## Descripción

Se realizó una pequeña refactorización de los endpoints del backend para mantener una estructura más consistente antes de comenzar la integración con el frontend.

## Cambios realizados

- Se unificaron los endpoints de listado y creación de compras.
- `GET /api/purchases/` continúa permitiendo consultar las compras.
- `POST /api/purchases/` ahora permite registrar una nueva compra.
- Se eliminó el endpoint redundante `POST /api/purchases/create/`.
- Se eliminó el endpoint temporal `admin-test/` utilizado durante las pruebas de permisos.
- Se mantuvieron sin cambios los endpoints de detalle, historial y cancelación de compras.

## Endpoints principales de compras

- `GET /api/purchases/`
- `POST /api/purchases/`
- `GET /api/purchases/<id>/`
- `PATCH /api/purchases/<id>/cancel/`
- `GET /api/purchases/customer/<customer_code>/`

## Pruebas realizadas

- Listado de compras.
- Registro de una nueva compra.
- Consulta del detalle de una compra.
- Cancelación de una compra.
- Consulta del historial de compras de un cliente.
- Validación de que `admin-test/` ya no esté disponible.
- Verificación general mediante `python manage.py check`.

Todas las pruebas finalizaron correctamente.