### PR TITLE
Add date filters to purchase history

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -123,7 +123,7 @@ AUTH_PASSWORD_VALIDATORS = [
 
 LANGUAGE_CODE = 'en-us'
 
-TIME_ZONE = 'UTC'
+TIME_ZONE = "America/Mexico_City"
 
 USE_I18N = True
 

--- a/backend/purchases/views.py
+++ b/backend/purchases/views.py
@@ -1,4 +1,5 @@
 from django.shortcuts import get_object_or_404
+from django.utils.dateparse import parse_date
 
 from rest_framework import (
     generics,
@@ -14,7 +15,6 @@ from rest_framework.permissions import (
 )
 
 from rest_framework.response import Response
-
 from rest_framework.views import APIView
 
 
@@ -48,6 +48,19 @@ class PurchaseListCreateView(
         request
     ):
 
+        date_from_param = (
+            request.query_params.get(
+                "date_from"
+            )
+        )
+
+        date_to_param = (
+            request.query_params.get(
+                "date_to"
+            )
+        )
+
+
         purchases = (
             Purchase.objects
             .select_related(
@@ -59,15 +72,109 @@ class PurchaseListCreateView(
             .prefetch_related(
                 "items__product"
             )
-            .order_by(
-                "-created_at"
-            )
         )
+
+
+        if date_from_param:
+
+            date_from = parse_date(
+                date_from_param
+            )
+
+            if not date_from:
+
+                return Response(
+                    {
+                        "detail": (
+                            "La fecha inicial "
+                            "no es válida."
+                        )
+                    },
+                    status=(
+                        status
+                        .HTTP_400_BAD_REQUEST
+                    )
+                )
+
+            purchases = purchases.filter(
+                created_at__date__gte=(
+                    date_from
+                )
+            )
+
+
+        if date_to_param:
+
+            date_to = parse_date(
+                date_to_param
+            )
+
+            if not date_to:
+
+                return Response(
+                    {
+                        "detail": (
+                            "La fecha final "
+                            "no es válida."
+                        )
+                    },
+                    status=(
+                        status
+                        .HTTP_400_BAD_REQUEST
+                    )
+                )
+
+            purchases = purchases.filter(
+                created_at__date__lte=(
+                    date_to
+                )
+            )
+
+
+        if (
+            date_from_param
+            and date_to_param
+        ):
+
+            date_from = parse_date(
+                date_from_param
+            )
+
+            date_to = parse_date(
+                date_to_param
+            )
+
+            if (
+                date_from
+                and date_to
+                and date_from > date_to
+            ):
+
+                return Response(
+                    {
+                        "detail": (
+                            "La fecha inicial "
+                            "no puede ser posterior "
+                            "a la fecha final."
+                        )
+                    },
+                    status=(
+                        status
+                        .HTTP_400_BAD_REQUEST
+                    )
+                )
+
+
+        purchases = purchases.order_by(
+            "-created_at"
+        )
+
 
         serializer = PurchaseSerializer(
             purchases,
             many=True
         )
+
 
         return Response(
             serializer.data
@@ -89,6 +196,7 @@ class PurchaseListCreateView(
             raise_exception=True
         )
 
+
         purchase = (
             PurchaseService
             .create_purchase(
@@ -97,9 +205,11 @@ class PurchaseListCreateView(
             )
         )
 
+
         serializer = PurchaseSerializer(
             purchase
         )
+
 
         return Response(
             serializer.data,
@@ -159,6 +269,7 @@ class CustomerPurchaseHistoryView(
             customer_code=customer_code
         )
 
+
         purchases = (
             Purchase.objects
             .filter(
@@ -178,9 +289,11 @@ class CustomerPurchaseHistoryView(
             )
         )
 
+
         return Response({
 
             "customer": {
+
                 "name": (
                     customer.user
                     .get_full_name()
@@ -193,6 +306,7 @@ class CustomerPurchaseHistoryView(
                 "points": (
                     customer.points
                 ),
+
             },
 
             "purchases": (
@@ -223,6 +337,7 @@ class MyPurchaseListView(
     ):
 
         user = self.request.user
+
 
         if user.role != "CUSTOMER":
 
@@ -287,6 +402,7 @@ class MyPurchaseDetailView(
     ):
 
         user = self.request.user
+
 
         if user.role != "CUSTOMER":
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1371,3 +1371,80 @@ th {
 .purchase-customer-summary p {
   margin: 0;
 }
+
+/* ==========================
+   Purchase Date Filters
+========================== */
+
+.purchase-filter-header {
+  display: flex;
+
+  align-items: flex-start;
+  justify-content: space-between;
+
+  gap: 20px;
+
+  margin-bottom: 20px;
+}
+
+.purchase-filter-header h2 {
+  margin: 0 0 6px;
+}
+
+.purchase-filter-header p {
+  margin: 0;
+
+  color: #666;
+}
+
+.purchase-date-filters {
+  display: flex;
+
+  align-items: flex-end;
+
+  flex-wrap: wrap;
+
+  gap: 16px;
+
+  margin-bottom: 24px;
+}
+
+.purchase-date-filters .form-group {
+  min-width: 180px;
+  margin: 0;
+}
+
+.purchase-date-filters input {
+  width: 100%;
+  height: 44px;
+
+  box-sizing: border-box;
+
+  padding: 0 12px;
+
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+
+  background: #ffffff;
+}
+
+
+@media (max-width: 768px) {
+
+  .purchase-filter-header {
+    flex-direction: column;
+  }
+
+  .purchase-date-filters {
+    display: grid;
+
+    grid-template-columns: 1fr;
+
+    width: 100%;
+  }
+
+  .purchase-date-filters .form-group {
+    width: 100%;
+  }
+
+}

--- a/frontend/src/pages/Purchases.jsx
+++ b/frontend/src/pages/Purchases.jsx
@@ -10,7 +10,49 @@ import {
 } from "../services/purchaseService";
 
 
+const getLocalDateString = () => {
+  const now = new Date();
+
+  const year =
+    now.getFullYear();
+
+  const month =
+    String(
+      now.getMonth() + 1
+    ).padStart(
+      2,
+      "0"
+    );
+
+  const day =
+    String(
+      now.getDate()
+    ).padStart(
+      2,
+      "0"
+    );
+
+
+  return (
+    `${year}-${month}-${day}`
+  );
+};
+
+
 function Purchases() {
+  const today =
+    getLocalDateString();
+
+
+  const [
+    filters,
+    setFilters,
+  ] = useState({
+    dateFrom: today,
+    dateTo: today,
+  });
+
+
   const [purchases, setPurchases] =
     useState([]);
 
@@ -24,15 +66,25 @@ function Purchases() {
   useEffect(() => {
     let cancelled = false;
 
-    getPurchases()
+
+    getPurchases(filters)
       .then((data) => {
         if (!cancelled) {
           setPurchases(data);
+
+          setError("");
         }
       })
-      .catch(() => {
+      .catch((requestError) => {
         if (!cancelled) {
+          const detail =
+            requestError
+              .response
+              ?.data
+              ?.detail;
+
           setError(
+            detail ||
             "No fue posible cargar las compras."
           );
         }
@@ -43,10 +95,102 @@ function Purchases() {
         }
       });
 
+
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [filters]);
+
+
+  const handleDateChange = (
+    event
+  ) => {
+    const {
+      name,
+      value,
+    } = event.target;
+
+
+    setLoading(true);
+
+    setFilters(
+      (currentFilters) => ({
+        ...currentFilters,
+        [name]: value,
+      })
+    );
+  };
+
+
+  const handleToday = () => {
+    const currentToday =
+      getLocalDateString();
+
+
+    if (
+      filters.dateFrom ===
+        currentToday
+      &&
+      filters.dateTo ===
+        currentToday
+    ) {
+      return;
+    }
+
+
+    setLoading(true);
+
+
+    setFilters({
+      dateFrom:
+        currentToday,
+
+      dateTo:
+        currentToday,
+    });
+  };
+
+
+  const formatFilterDate = (
+    dateString
+  ) => {
+    if (!dateString) {
+      return "";
+    }
+
+
+    const [
+      year,
+      month,
+      day,
+    ] = dateString.split(
+      "-"
+    );
+
+
+    return (
+      `${day}/${month}/${year}`
+    );
+  };
+
+
+  const periodText = (
+    filters.dateFrom &&
+    filters.dateTo
+  )
+    ? filters.dateFrom ===
+      filters.dateTo
+      ? formatFilterDate(
+          filters.dateFrom
+        )
+      : (
+          `${formatFilterDate(
+            filters.dateFrom
+          )} al ${formatFilterDate(
+            filters.dateTo
+          )}`
+        )
+    : "Periodo seleccionado";
 
 
   return (
@@ -55,6 +199,7 @@ function Purchases() {
       <header className="page-header page-header-actions">
 
         <div>
+
           <h1>
             Compras
           </h1>
@@ -62,6 +207,7 @@ function Purchases() {
           <p>
             Consulta y registra las compras de los clientes.
           </p>
+
         </div>
 
 
@@ -77,29 +223,119 @@ function Purchases() {
 
       <section className="dashboard-section">
 
-        <h2>
-          Historial de compras
-        </h2>
+        <div className="purchase-filter-header">
+
+          <div>
+
+            <h2>
+              Historial de compras
+            </h2>
+
+            <p>
+              Mostrando:{" "}
+              <strong>
+                {periodText}
+              </strong>
+            </p>
+
+          </div>
+
+
+          <button
+            type="button"
+            className="secondary-action"
+            onClick={
+              handleToday
+            }
+          >
+            Hoy
+          </button>
+
+        </div>
+
+
+        <div className="purchase-date-filters">
+
+          <div className="form-group">
+
+            <label htmlFor="dateFrom">
+              Desde
+            </label>
+
+            <input
+              id="dateFrom"
+              name="dateFrom"
+              type="date"
+              value={
+                filters.dateFrom
+              }
+              onChange={
+                handleDateChange
+              }
+            />
+
+          </div>
+
+
+          <div className="form-group">
+
+            <label htmlFor="dateTo">
+              Hasta
+            </label>
+
+            <input
+              id="dateTo"
+              name="dateTo"
+              type="date"
+              value={
+                filters.dateTo
+              }
+              min={
+                filters.dateFrom ||
+                undefined
+              }
+              onChange={
+                handleDateChange
+              }
+            />
+
+          </div>
+
+        </div>
 
 
         {loading ? (
+
           <p>
             Cargando compras...
           </p>
+
         ) : error ? (
-          <p role="alert">
+
+          <p
+            role="alert"
+            className="form-error"
+          >
             {error}
           </p>
-        ) : purchases.length === 0 ? (
+
+        ) : purchases.length ===
+          0 ? (
+
           <p>
-            No hay compras registradas.
+            No hay compras registradas en este periodo.
           </p>
+
         ) : (
+
           <div className="table-container">
 
             <table>
+
               <thead>
+
                 <tr>
+
                   <th>
                     Compra
                   </th>
@@ -131,25 +367,47 @@ function Purchases() {
                   <th>
                     Acciones
                   </th>
+
                 </tr>
+
               </thead>
 
+
               <tbody>
+
                 {purchases.map(
                   (purchase) => (
-                    <tr key={purchase.id}>
+
+                    <tr
+                      key={
+                        purchase.id
+                      }
+                      className={
+                        purchase.status ===
+                        "CANCELLED"
+                          ? "purchase-row-cancelled"
+                          : ""
+                      }
+                    >
 
                       <td>
                         #{purchase.id}
                       </td>
 
-                      <td>
-                        {purchase.customer_name}
-                      </td>
 
                       <td>
-                        {purchase.customer_code}
+                        {
+                          purchase.customer_name
+                        }
                       </td>
+
+
+                      <td>
+                        {
+                          purchase.customer_code
+                        }
+                      </td>
+
 
                       <td>
                         $
@@ -158,13 +416,21 @@ function Purchases() {
                         ).toFixed(2)}
                       </td>
 
-                      <td>
-                        {purchase.points_earned}
-                      </td>
 
                       <td>
-                        {purchase.status}
+                        {
+                          purchase.points_earned
+                        }
                       </td>
+
+
+                      <td>
+                        {purchase.status ===
+                        "COMPLETED"
+                          ? "Completada"
+                          : "Cancelada"}
+                      </td>
+
 
                       <td>
                         {new Date(
@@ -172,22 +438,29 @@ function Purchases() {
                         ).toLocaleString()}
                       </td>
 
+
                       <td>
+
                         <Link
                           to={`/purchases/${purchase.id}`}
                           className="action-link"
                         >
                           Ver detalle
                         </Link>
+
                       </td>
 
                     </tr>
+
                   )
                 )}
+
               </tbody>
+
             </table>
 
           </div>
+
         )}
 
       </section>

--- a/frontend/src/services/purchaseService.js
+++ b/frontend/src/services/purchaseService.js
@@ -1,16 +1,37 @@
 import api from "../api/axios";
 
 
-export const getPurchases = async () => {
+export const getPurchases = async (
+  filters = {}
+) => {
+  const params = {};
+
+  if (filters.dateFrom) {
+    params.date_from =
+      filters.dateFrom;
+  }
+
+  if (filters.dateTo) {
+    params.date_to =
+      filters.dateTo;
+  }
+
+
   const response = await api.get(
-    "/purchases/"
+    "/purchases/",
+    {
+      params,
+    }
   );
+
 
   return response.data;
 };
 
 
-export const getPurchaseById = async (id) => {
+export const getPurchaseById = async (
+  id
+) => {
   const response = await api.get(
     `/purchases/${id}/`
   );
@@ -19,7 +40,9 @@ export const getPurchaseById = async (id) => {
 };
 
 
-export const createPurchase = async (data) => {
+export const createPurchase = async (
+  data
+) => {
   const response = await api.post(
     "/purchases/",
     data
@@ -29,7 +52,9 @@ export const createPurchase = async (data) => {
 };
 
 
-export const cancelPurchase = async (id) => {
+export const cancelPurchase = async (
+  id
+) => {
   const response = await api.patch(
     `/purchases/${id}/cancel/`
   );
@@ -47,7 +72,9 @@ export const getMyPurchases = async () => {
 };
 
 
-export const getMyPurchaseById = async (id) => {
+export const getMyPurchaseById = async (
+  id
+) => {
   const response = await api.get(
     `/purchases/me/${id}/`
   );


### PR DESCRIPTION
## Descripción

Se mejoró el módulo de compras para permitir consultar el historial por rango de fechas.

Al ingresar al módulo ahora se muestran únicamente las compras correspondientes al día actual, con la posibilidad de seleccionar una fecha inicial y una fecha final.

## Backend

- [x] Agregar filtros opcionales por fecha inicial.
- [x] Agregar filtros opcionales por fecha final.
- [x] Permitir consultar un rango de fechas.
- [x] Validar formato de fechas.
- [x] Validar que la fecha inicial no sea posterior a la fecha final.
- [x] Mantener las compras ordenadas de más reciente a más antigua.
- [x] Mantener visibles las compras canceladas.
- [x] Configurar la zona horaria del proyecto para `America/Mexico_City`.

## Frontend

- [x] Mostrar por defecto las compras del día actual.
- [x] Agregar selector de fecha inicial.
- [x] Agregar selector de fecha final.
- [x] Mostrar claramente el periodo consultado.
- [x] Agregar acción rápida para volver a "Hoy".
- [x] Mostrar mensaje cuando no existan compras en el periodo.
- [x] Mantener acceso al detalle de cada compra.
- [x] Mostrar estados de compra en español.
- [x] Diferenciar visualmente compras canceladas.
- [x] Agregar diseño responsive para los filtros.

## Validaciones realizadas

- [x] Consulta de compras del día actual.
- [x] Consulta de un solo día anterior.
- [x] Consulta de rangos de varios días.
- [x] Inclusión correcta de ambas fechas límite.
- [x] Consulta de periodos sin compras.
- [x] Visualización de compras canceladas.
- [x] Validación de fechas inválidas.
- [x] Validación de fecha inicial posterior a fecha final.
- [x] Funcionamiento correcto con ADMIN.
- [x] Funcionamiento correcto con EMPLOYEE.
- [x] `python manage.py check` sin errores.
- [x] `npm run lint` sin errores.