### PR TITLE
Fix mobile navigation logo sizing

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -4451,3 +4451,55 @@ input[type="number"]::-webkit-outer-spin-button {
   }
 
 }
+
+/* =========================================================
+   42. Mobile Brand Image Safety Fix
+========================================================= */
+
+@media (max-width: 768px) {
+  .mobile-brand-icon {
+    flex: 0 0 36px !important;
+    width: 36px !important;
+    height: 36px !important;
+    min-width: 36px !important;
+    min-height: 36px !important;
+    max-width: 36px !important;
+    max-height: 36px !important;
+    overflow: hidden !important;
+  }
+
+  .mobile-navigation-brand img,
+  .mobile-brand-icon img,
+  img.mobile-brand-mark,
+  img.mobile-brand-icon {
+    display: block !important;
+    flex: 0 0 24px !important;
+    width: 24px !important;
+    height: 24px !important;
+    min-width: 24px !important;
+    min-height: 24px !important;
+    max-width: 24px !important;
+    max-height: 24px !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    object-fit: contain !important;
+    object-position: center !important;
+    transform: none !important;
+  }
+
+  .sidebar-brand-logo {
+    width: 148px !important;
+    height: 56px !important;
+    max-width: 148px !important;
+    max-height: 56px !important;
+    object-fit: contain !important;
+  }
+
+  .sidebar-brand-collapsed img {
+    width: 30px !important;
+    height: 30px !important;
+    max-width: 30px !important;
+    max-height: 30px !important;
+    object-fit: contain !important;
+  }
+}


### PR DESCRIPTION
## Descripción

Se corrige el problema visual del logo de Frio&Co en dispositivos móviles.

El icono del copo de nieve podía renderizarse con un tamaño excesivamente grande y cubrir parte de la interfaz, bloqueando el acceso al menú móvil.

## Cambios realizados

- Se limita el tamaño del contenedor del logo móvil.
- Se limita explícitamente el tamaño de las imágenes utilizadas dentro del branding móvil.
- Se evita el desbordamiento del icono.
- Se agregan restricciones adicionales para mantener tamaños consistentes en sidebar expandido y colapsado.
- Se conserva el comportamiento actual en escritorio.

## Pruebas realizadas

- Navegación móvil validada en local.
- El icono del copo de nieve ya no cubre la interfaz.
- El menú móvil puede utilizarse normalmente.
- La aplicación compila correctamente.

## Resultado

El branding móvil ahora mantiene dimensiones controladas y funciona correctamente en pantallas pequeñas.